### PR TITLE
添加权限掩码umask设置

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM lsiobase/alpine:3.15
 # environment settings
 ENV TZ=Asia/Shanghai \
     WEBUI_PORT=8080 \
-    PUID=1026 PGID=100 \
+    PUID=1026 PGID=100 UMASK_SET=022\
     TL=https://githubraw.sleele.workers.dev/XIU2/TrackersListCollection/master/best.txt \
     UT=true
 

--- a/root/etc/services.d/qbittorrent/run
+++ b/root/etc/services.d/qbittorrent/run
@@ -1,5 +1,10 @@
 #!/usr/bin/with-contenv bash
 
+# 设置权限掩码umask
+
+UMASK_SET=${UMASK_SET:-000}
+umask $UMASK_SET
+
 # 启动qBittorrent
 exec \
 	s6-setuidgid abc qbittorrent-nox --webui-port=$WEBUI_PORT --profile=/config


### PR DESCRIPTION
添加权限掩码umask设置以适应除了群晖以外的其它系统